### PR TITLE
Fix non-working example in the "Interoperability" documentation 

### DIFF
--- a/manual/content/chapter-1/page-1-f.md
+++ b/manual/content/chapter-1/page-1-f.md
@@ -131,7 +131,7 @@ bytecoder.imports.math = {
 At startup, the following code must be provided:
 
 ```
-bytecoder.imports.math = {
+bytecoder.imports.tmath = {
     sqrtDOUBLE: function(thisref, p1) {
         return Math.sqrt(p1);
     },


### PR DESCRIPTION
Hi,
thanks for your work in this great project. 

I'm currently researching for an university project on how to convert Java application to WebAssembly. I got slightly stuck on how to call JavaScript functions from my Java code.

Your suggested JavaScript-Code:
```
bytecoder.imports.math = {
    sqrtDOUBLE: function(p1) {
        return Math.sqrt(p1);
    },
};
```
causes this error in my web console: `LinkError: import object field 'minINTINT' is not a Function`
I guess I'm overriding the default implementation for min(x,y).

But changing bytecoder.imports.math to bytecoder.imports.tmath does the trick. It seems that bytecoder.imports need the hole Java class name.
My Code:

```javascript
bytecoder.imports.tmath = {
    sqrtDOUBLE: function(thisref, p1) {
        return 42;
    },
};
```
```java
import de.mirkosertic.bytecoder.classlib.java.lang.TObject;
public class TMath extends TObject {
  public static native double sqrt(double aValue);
}
```
```java
import de.mirkosertic.bytecoder.api.Export;
public class Main {
  public static void main(String[] args) {
  }
  @Export("example_getValueFromJavaScriptLib")
  public static double getValueFromJavaScriptLib() {
    return TMath.sqrt(2.0);
  }
}
```
```javascript
console.assert(bytecoder.exports.example_getValueFromJavaScriptLib(0) === 42);
```