### PR TITLE
BytecoderUnitTestRunner - skip docker tests when docker not present

### DIFF
--- a/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderTestOptions.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderTestOptions.java
@@ -33,4 +33,6 @@ public @interface BytecoderTestOptions {
     String[] additionalClassesToLink() default {};
 
     String[] additionalResources() default {};
+
+    boolean skipDockerTestsWhenDockerNotPresent() default false;
 }

--- a/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
@@ -727,6 +727,14 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
         if (o.getBackendType() == null) {
             testJVMBackendFrameworkMethod(aFrameworkMethod, aRunNotifier);
         } else {
+            if (skipDockerTests) {
+                aRunNotifier.fireTestIgnored(
+                    Description.createTestDescription(
+                        getTestClass().getJavaClass(),
+                        aFrameworkMethod.getName() + " " + aFrameworkMethod.getTestOption().toDescription()
+                    )
+                );
+            }
             switch (o.getBackendType()) {
                 case js:
                     testJSBackendFrameworkMethod(aFrameworkMethod, aRunNotifier, o);

--- a/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
@@ -31,6 +31,7 @@ import de.mirkosertic.bytecoder.core.BytecodeObjectTypeRef;
 import de.mirkosertic.bytecoder.core.BytecodePrimitiveTypeRef;
 import de.mirkosertic.bytecoder.core.BytecodeTypeRef;
 import de.mirkosertic.bytecoder.optimizer.KnownOptimizer;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -74,6 +75,7 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
     private final List<TestOption> testOptions;
     private final String[] additionalClassesToLink;
     private final String[] additionalResources;
+    private boolean skipDockerTests = false;
 
     private static HttpServer TESTSERVER;
     private static BrowserWebDriverContainer SELENIUMCONTAINER;
@@ -103,6 +105,13 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
             }
             additionalClassesToLink = declaredOptions.additionalClassesToLink();
             additionalResources = declaredOptions.additionalResources();
+            if (declaredOptions.skipDockerTestsWhenDockerNotPresent()) {
+                try {
+                    new ProcessBuilder().command("docker", "help").start().waitFor(1, TimeUnit.SECONDS);
+                } catch (IOException | InterruptedException exception) {
+                    skipDockerTests = true;
+                }
+            }
         } else {
             testOptions.add(new TestOption(null, false, false, false));
             testOptions.add(new TestOption(CompileTarget.BackendType.js, false, false, false));


### PR DESCRIPTION
I encountered another problem.

I'm developing on:
- Windows without Docker 
- Ubuntu with Docker

When I'm building the project on Windows, all unit tests which will use docker must and will fail. 

Instead of using "mvn clean package -DskipTests=true", I added the flag "skipDockerTestsWhenDockerNotPresent" to the BytecoderTestOptions annotation.

If you consider this feature useful, you can add it.