### PR TITLE
BytecoderUnitTestRunner - inject javascript code before test

### DIFF
--- a/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/unittest/BytecoderUnitTestRunner.java
@@ -285,6 +285,12 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
 
                 theCodeWriter.println("console.log(\"Starting test\");");
                 theCodeWriter.println("bytecoder.bootstrap();");
+
+                if (aFrameworkMethod.getMethod().isAnnotationPresent(ExecuteJavaScriptBeforeTest.class)) {
+                    theCodeWriter.println(aFrameworkMethod.getMethod().getAnnotation(ExecuteJavaScriptBeforeTest.class).value());
+                    theCodeWriter.println("");
+                }
+
                 theCodeWriter.println("var theTestInstance = " + result.getMinifier().toClassName(theTestClass) + "." +  result.getMinifier().toSymbol("__runtimeclass") + "." + result.getMinifier().toMethodName("$newInstance", theTestClassConstructorSignature) + "();");
                 theCodeWriter.println("try {");
                 theCodeWriter.println("     theTestInstance." + result.getMinifier().toMethodName(aFrameworkMethod.getName(), theSignature) + "();");
@@ -403,6 +409,11 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
                 theWriter.println("        <script>");
 
                 theWriter.println(jsContent.asString());
+
+                if (aFrameworkMethod.getMethod().isAnnotationPresent(ExecuteJavaScriptBeforeTest.class)) {
+                    theWriter.println(aFrameworkMethod.getMethod().getAnnotation(ExecuteJavaScriptBeforeTest.class).value());
+                    theWriter.println("");
+                }
 
                 theWriter.println("            function compile() {");
                 theWriter.println("                console.log('Test started');");
@@ -585,6 +596,11 @@ public class BytecoderUnitTestRunner extends ParentRunner<FrameworkMethodWithTes
                 theWriter.println("        <script>");
 
                 theWriter.println(jsContent.asString());
+
+                if (aFrameworkMethod.getMethod().isAnnotationPresent(ExecuteJavaScriptBeforeTest.class)) {
+                    theWriter.println(aFrameworkMethod.getMethod().getAnnotation(ExecuteJavaScriptBeforeTest.class).value());
+                    theWriter.println("");
+                }
 
                 theWriter.println("            function compile() {");
                 theWriter.println("                console.log('Test started');");

--- a/core/src/main/java/de/mirkosertic/bytecoder/unittest/ExecuteJavaScriptBeforeTest.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/unittest/ExecuteJavaScriptBeforeTest.java
@@ -1,0 +1,16 @@
+package de.mirkosertic.bytecoder.unittest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExecuteJavaScriptBeforeTest {
+
+  /**
+   * @return JS-Code which should be executed before the test runs
+   */
+  String value();
+}


### PR DESCRIPTION
This is my last pull request :)

In my unit test, I wanted to test the "Importing functionality from the host environment" - but I found no way to do this.

That's why I created a new Annotation and add code to the testJSBackendFrameworkMethod, testWASMASTBackendFrameworkMethod and testLLVMWASMASTBackendFrameworkMethod.

With this change, my test now work (with includeJVM=false because the test can only work with JavaScript/WebAssembly):
```
public class BusinessLogic {
  public static native int return42();
}
public class Main {
  @Export("jslib_return42")
  public static int return42() {
    return BusinessLogic.return42();
  }
}
@RunWith(BytecoderUnitTestRunner.class)
@BytecoderTestOptions(value = {
    @BytecoderTestOption(
        backend = CompileTarget.BackendType.wasm,
        preferStackifier = false,
        exceptionsEnabled = false,
        minify = false
    )},
    includeJVM = false,
)
public class MainTest {
  @Test
  @ExecuteJS("bytecoder.imports.businesslogic = {return42: function (thisref, v) {return 42;}};")
  public void return42_withNoArgs_return42() {
    assertEquals(42, Main.return42());
  }
}
```

If you consider this feature useful, you can add it.