### PR TITLE
OpenCL/CPUContext: use the Common ForkJoinPool instead of a FixedThreadPool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/target/*
 **/.DS_Store
 /manual/public/
+.llvm
 
 # Eclipse
 .settings

--- a/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/Float2.java
+++ b/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/Float2.java
@@ -53,7 +53,8 @@ public class Float2 implements FloatSerializable {
     }
 
     static Float2 normalize(final Float2 aVector) {
-        throw new IllegalArgumentException("Not implemented for CPU emulation");
+        float length = aVector.length();
+        return float2(aVector.s0 / length, aVector.s1 / length);
     }
 
     float length() {

--- a/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/OpenCLOptions.java
+++ b/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/OpenCLOptions.java
@@ -109,18 +109,20 @@ public class OpenCLOptions {
          * There are different output styles available for generated code.
          * @param codeGeneratorStyle
          */
-        public void codeGeneratorStyle(CodeGeneratorStyle codeGeneratorStyle) {
+        public OpenCLOptionsBuilder codeGeneratorStyle(CodeGeneratorStyle codeGeneratorStyle) {
             Objects.requireNonNull(codeGeneratorStyle);
             this.codeGeneratorStyle = codeGeneratorStyle;
+            return this;
         }
         
         /**
          * Platforms are rejected if the platformFilter predicate returns false.
          * @param platformFilter
          */
-        public void setPlatformFilter(Predicate<PlatformProperties> platformFilter) {
+        public OpenCLOptionsBuilder platformFilter(Predicate<PlatformProperties> platformFilter) {
             Objects.requireNonNull(platformFilter);
             this.platformFilter = platformFilter;
+            return this;
         }
         
         /**
@@ -128,9 +130,10 @@ public class OpenCLOptions {
          * overridden by system property {@code OPENCL_DEVICE}.  
          * @param preferredPlatformComparator
          */
-        public void setPreferredDeviceComparator(Comparator<DeviceProperties> preferredDeviceComparator) {
+        public OpenCLOptionsBuilder preferredDeviceComparator(Comparator<DeviceProperties> preferredDeviceComparator) {
             Objects.requireNonNull(preferredDeviceComparator);
             this.preferredDeviceComparator = preferredDeviceComparator;
+            return this;
         }
         
         public OpenCLOptions build() {

--- a/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/OpenCLOptions.java
+++ b/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/OpenCLOptions.java
@@ -15,15 +15,133 @@
  */
 package de.mirkosertic.bytecoder.api.opencl;
 
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.function.Predicate;
+
 public class OpenCLOptions {
 
-    private final boolean preferStackifier;
+    public static enum CodeGeneratorStyle {
+        
+        /**
+         * The Stackifier tries to remove all GOTO statements and 
+         * replaces them with structured control flow elements and multi level break and continues. 
+         * <p>
+         * The Stackifier does only work for reducible control flows and also does not support 
+         * exception handling. The generated output is smaller and in some cases faster compared 
+         * to the Relooper output.
+         */
+        STACKIFIER,
+        
+        /**
+         * The Relooper output generator tries to recover high level control flow constructs 
+         * from the intermediate representation. This step eliminates the needs of GOTO 
+         * statements and thus allows generation of more natural source code, which in turn 
+         * can be easier read and optimized by Web Browsers or other tools.
+         * <p> 
+         * The Relooper supports all styles of control flows and also supports exception handling.
+         */
+        RELOOPER
+    }
+    
+    private final CodeGeneratorStyle codeGeneratorStyle;
+    public CodeGeneratorStyle getCodeGeneratorStyle() {
+        return codeGeneratorStyle;
+    }
+    
+    private final Predicate<PlatformProperties> platformFilter;
+    public Predicate<PlatformProperties> getPlatformFilter() {
+        return platformFilter;
+    }
+    
+    private final Comparator<DeviceProperties> preferredDeviceComparator;
+    public Comparator<DeviceProperties> getPreferredDeviceComparator() {
+        return preferredDeviceComparator;
+    }
 
+    /** 
+     * @apiNote not exposed, use builder to create an instance 
+     */
+    private OpenCLOptions(
+            final CodeGeneratorStyle codeGeneratorStyle, 
+            final Predicate<PlatformProperties> platformFilter,
+            final Comparator<DeviceProperties> preferredDeviceComparator) {
+        this.codeGeneratorStyle = codeGeneratorStyle;
+        this.platformFilter = platformFilter;
+        this.preferredDeviceComparator = preferredDeviceComparator;
+    }
+
+    /**
+     * 
+     * @deprecated use {@link OpenCLOptions#builder()} instead.
+     * 
+     */
+    @Deprecated
     public OpenCLOptions(final boolean preferStackifier) {
-        this.preferStackifier = preferStackifier;
+        this.codeGeneratorStyle = preferStackifier
+                ? CodeGeneratorStyle.STACKIFIER
+                : CodeGeneratorStyle.RELOOPER;
+        final OpenCLOptions defaults = defaults();
+        this.platformFilter = defaults.getPlatformFilter();
+        this.preferredDeviceComparator = defaults.getPreferredDeviceComparator();
     }
 
     public boolean isPreferStackifier() {
-        return preferStackifier;
+        return codeGeneratorStyle == CodeGeneratorStyle.STACKIFIER;
     }
+
+    // -- DEFAULTS
+    
+    public static OpenCLOptions defaults() {
+        return OpenCLOptions.builder().build();
+    }
+    
+    // -- OPTIONS BUILDER
+    
+    public static final class OpenCLOptionsBuilder {
+        private CodeGeneratorStyle codeGeneratorStyle = CodeGeneratorStyle.STACKIFIER;
+        private Predicate<PlatformProperties> platformFilter = p -> true;
+        private Comparator<DeviceProperties> preferredDeviceComparator = (a, b) -> Integer.compare(
+                a.getNumberOfComputeUnits(),
+                b.getNumberOfComputeUnits());
+        
+        /**
+         * There are different output styles available for generated code.
+         * @param codeGeneratorStyle
+         */
+        public void codeGeneratorStyle(CodeGeneratorStyle codeGeneratorStyle) {
+            Objects.requireNonNull(codeGeneratorStyle);
+            this.codeGeneratorStyle = codeGeneratorStyle;
+        }
+        
+        /**
+         * Platforms are rejected if the platformFilter predicate returns false.
+         * @param platformFilter
+         */
+        public void setPlatformFilter(Predicate<PlatformProperties> platformFilter) {
+            Objects.requireNonNull(platformFilter);
+            this.platformFilter = platformFilter;
+        }
+        
+        /**
+         * The device that compares highest is chosen by the {@link PlatformFactory}, unless explicitly 
+         * overridden by system property {@code OPENCL_DEVICE}.  
+         * @param preferredPlatformComparator
+         */
+        public void setPreferredDeviceComparator(Comparator<DeviceProperties> preferredDeviceComparator) {
+            Objects.requireNonNull(preferredDeviceComparator);
+            this.preferredDeviceComparator = preferredDeviceComparator;
+        }
+        
+        public OpenCLOptions build() {
+            return new OpenCLOptions(codeGeneratorStyle, platformFilter, preferredDeviceComparator);
+        }
+    }
+    
+    public static OpenCLOptionsBuilder builder() {
+        return new OpenCLOptionsBuilder();
+    }
+    
+
+    
 }

--- a/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/PlatformFactory.java
+++ b/classlib/bytecoder.opencl/src/main/java/de/mirkosertic/bytecoder/api/opencl/PlatformFactory.java
@@ -26,5 +26,16 @@ public abstract class PlatformFactory {
         return theLoader.iterator().next();
     }
 
+    /**
+     * Creates a {@link Platform} with default {@link OpenCLOptions}
+     * @param aLogger
+     * @return
+     */
+    public Platform createPlatform(final Logger aLogger) {
+        return createPlatform(aLogger, OpenCLOptions.defaults());
+    }
+    
     public abstract Platform createPlatform(Logger aLogger, OpenCLOptions aOptions);
+    
+    
 }

--- a/core/src/main/java/de/mirkosertic/bytecoder/backend/opencl/CPUContextUsingFixedThreadPool.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/backend/opencl/CPUContextUsingFixedThreadPool.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Mirko Sertic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.mirkosertic.bytecoder.backend.opencl;
+
+import static de.mirkosertic.bytecoder.api.opencl.GlobalFunctions.set_global_id;
+import static de.mirkosertic.bytecoder.api.opencl.GlobalFunctions.set_global_size;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+import de.mirkosertic.bytecoder.api.opencl.Context;
+import de.mirkosertic.bytecoder.api.opencl.Kernel;
+import de.mirkosertic.bytecoder.api.Logger;
+
+public class CPUContextUsingFixedThreadPool implements Context {
+
+    private final ExecutorService executorService;
+    private final Logger logger;
+
+    public CPUContextUsingFixedThreadPool(Logger aLogger) {
+        logger = aLogger;
+        executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors(), new ThreadFactory() {
+
+            int counter = 0;
+
+            @Override
+            public Thread newThread(Runnable aRunnable) {
+                return new Thread(aRunnable, "OpenCL-CPU#" + (counter ++));
+            }
+        });
+    }
+
+    @Override
+    public void compute(int aNumberOfStreams, Kernel aKernel) {
+        CountDownLatch theLatch = new CountDownLatch(aNumberOfStreams);
+        for (int i=0;i<aNumberOfStreams;i++) {
+            final int theWorkItemId = i;
+            executorService.submit(() -> {
+                try {
+                    set_global_id(0, theWorkItemId);
+                    set_global_size(0, aNumberOfStreams);
+                    aKernel.processWorkItem();
+                } finally {
+                    theLatch.countDown();
+                }
+            });
+        }
+        try {
+            theLatch.await();
+        } catch (InterruptedException e) {
+            throw new IllegalStateException("Something went wrong", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        executorService.shutdownNow();
+    }
+}

--- a/core/src/test/java/de/mirkosertic/bytecoder/api/opencl/ContextTest.java
+++ b/core/src/test/java/de/mirkosertic/bytecoder/api/opencl/ContextTest.java
@@ -112,7 +112,7 @@ public class ContextTest {
         final Float2[] theResult = new Float2[] {float2(-1f, -1f)};
 
         try (final Context theContext = thePlatform.createContext()) {
-            theContext.compute(1, new Kernel() {
+            theContext.compute(theA.length, new Kernel() {
                 @Override
                 public void processWorkItem() {
                     final int id = get_global_id(0);
@@ -135,7 +135,7 @@ public class ContextTest {
         final Float2[] theResult = new Float2[] {float2(0f, 0f), float2(0f, 0f)};
 
         try (final Context theContext = thePlatform.createContext()) {
-            theContext.compute(4, new Kernel() {
+            theContext.compute(theA.length, new Kernel() {
                 @Override
                 public void processWorkItem() {
                     final int id = get_global_id(0);
@@ -159,7 +159,7 @@ public class ContextTest {
         final Float2[] theResult = new Float2[] {float2(0f, 0f), float2(0f, 0f)};
 
         try (final Context theContext = thePlatform.createContext()) {
-            theContext.compute(4, new Kernel() {
+            theContext.compute(theA.length, new Kernel() {
                 @Override
                 public void processWorkItem() {
                     final int id = get_global_id(0);


### PR DESCRIPTION
in reference to #462

Renames the former `CPUContext` to `CPUContextUsingFixedThreadPool`. If one want's to use the old one, there is a new CPUPlatform constructor, that allows to override default behavior.

```java
CPUPlatform customCPUPlatform = new CPUPlatform(aLogger, CPUContextUsingFixedThreadPool::new);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mirkosertic/bytecoder/463)
<!-- Reviewable:end -->
