### PR TITLE
Rename ClickEvent to MouseEvent and add type() to Event

### DIFF
--- a/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/Event.java
+++ b/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/Event.java
@@ -21,6 +21,6 @@ import de.mirkosertic.bytecoder.api.OpaqueReferenceType;
 public interface Event extends OpaqueReferenceType {
 
     @OpaqueProperty
-    String getType();
+    String type();
 
 }

--- a/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/Event.java
+++ b/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/Event.java
@@ -15,7 +15,12 @@
  */
 package de.mirkosertic.bytecoder.api.web;
 
+import de.mirkosertic.bytecoder.api.OpaqueProperty;
 import de.mirkosertic.bytecoder.api.OpaqueReferenceType;
 
 public interface Event extends OpaqueReferenceType {
+
+    @OpaqueProperty
+    String getType();
+
 }

--- a/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/MouseEvent.java
+++ b/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/MouseEvent.java
@@ -17,7 +17,7 @@ package de.mirkosertic.bytecoder.api.web;
 
 import de.mirkosertic.bytecoder.api.OpaqueProperty;
 
-public interface ClickEvent extends Event {
+public interface MouseEvent extends Event {
 
     @OpaqueProperty
     float clientX();

--- a/core/src/test/java/de/mirkosertic/bytecoder/classlib/GCTest.java
+++ b/core/src/test/java/de/mirkosertic/bytecoder/classlib/GCTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import de.mirkosertic.bytecoder.api.web.ClickEvent;
+import de.mirkosertic.bytecoder.api.web.MouseEvent;
 import de.mirkosertic.bytecoder.api.web.EventListener;
 import de.mirkosertic.bytecoder.api.web.EventTarget;
 import de.mirkosertic.bytecoder.api.web.Window;
@@ -34,10 +34,10 @@ import de.mirkosertic.bytecoder.unittest.BytecoderUnitTestRunner;
 }, includeJVM = false)
 public class GCTest {
 
-    private static EventListener<ClickEvent> registerClicklistenerOn(final EventTarget target) {
-        final EventListener<ClickEvent> listener = new EventListener<ClickEvent>() {
+    private static EventListener<MouseEvent> registerClicklistenerOn(final EventTarget target) {
+        final EventListener<MouseEvent> listener = new EventListener<MouseEvent>() {
             @Override
-            public void run(ClickEvent aEvent) {
+            public void run(MouseEvent aEvent) {
 
             }
         };
@@ -48,7 +48,7 @@ public class GCTest {
     @Test
     public void testListenerGC() {
         final Window w = Window.window();
-        final EventListener<ClickEvent> listener = registerClicklistenerOn(w);
+        final EventListener<MouseEvent> listener = registerClicklistenerOn(w);
         final int ptr = Address.ptrOf(listener);
         Assert.assertTrue(MemoryManager.isUsedAsCallback(ptr));
         Assert.assertFalse(MemoryManager.isUsedByHeapUserSpace(ptr));

--- a/core/src/test/java/de/mirkosertic/bytecoder/classlib/GCTestStackless.java
+++ b/core/src/test/java/de/mirkosertic/bytecoder/classlib/GCTestStackless.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import de.mirkosertic.bytecoder.api.web.ClickEvent;
+import de.mirkosertic.bytecoder.api.web.MouseEvent;
 import de.mirkosertic.bytecoder.api.web.EventListener;
 import de.mirkosertic.bytecoder.api.web.EventTarget;
 import de.mirkosertic.bytecoder.api.web.Window;
@@ -34,10 +34,10 @@ import de.mirkosertic.bytecoder.unittest.BytecoderUnitTestRunner;
 }, includeJVM = false)
 public class GCTestStackless {
 
-    private static EventListener<ClickEvent> registerClicklistenerOn(final EventTarget target) {
-        final EventListener<ClickEvent> listener = new EventListener<ClickEvent>() {
+    private static EventListener<MouseEvent> registerClicklistenerOn(final EventTarget target) {
+        final EventListener<MouseEvent> listener = new EventListener<MouseEvent>() {
             @Override
-            public void run(ClickEvent aEvent) {
+            public void run(MouseEvent aEvent) {
 
             }
         };
@@ -48,7 +48,7 @@ public class GCTestStackless {
     @Test
     public void testListenerGC() {
         final Window w = Window.window();
-        final EventListener<ClickEvent> listener = registerClicklistenerOn(w);
+        final EventListener<MouseEvent> listener = registerClicklistenerOn(w);
         final int ptr = Address.ptrOf(listener);
         Assert.assertTrue(MemoryManager.isUsedAsCallback(ptr));
         Assert.assertFalse(MemoryManager.isUsedByHeapUserSpace(ptr));

--- a/core/src/test/kotlin/de/mirkosertic/bytecoder/core/OpaqueReferenceKotlinTest.kt
+++ b/core/src/test/kotlin/de/mirkosertic/bytecoder/core/OpaqueReferenceKotlinTest.kt
@@ -15,7 +15,7 @@
  */
 package de.mirkosertic.bytecoder.core
 
-import de.mirkosertic.bytecoder.api.web.ClickEvent
+import de.mirkosertic.bytecoder.api.web.MouseEvent
 import de.mirkosertic.bytecoder.api.web.EventListener
 import de.mirkosertic.bytecoder.api.web.HTMLDocument
 import de.mirkosertic.bytecoder.api.web.Window
@@ -35,7 +35,7 @@ class OpaqueReferenceKotlinTest {
     fun setTitleTest() {
         val w = Window.window()
         val d = w.document()
-        d.addEventListener("click", EventListener<ClickEvent> {
+        d.addEventListener("click", EventListener<MouseEvent> {
             d.title("Hello world!!")
         })
     }
@@ -44,7 +44,7 @@ class OpaqueReferenceKotlinTest {
     fun setTitleTestMember() {
         window = Window.window()
         document = window!!.document()
-        document!!.addEventListener("click", EventListener<ClickEvent> {
+        document!!.addEventListener("click", EventListener<MouseEvent> {
             document!!.title("Hello world!!")
         })
     }

--- a/integrationtest/src/main/java/de/mirkosertic/bytecoder/integrationtest/JBox2DSimulation.java
+++ b/integrationtest/src/main/java/de/mirkosertic/bytecoder/integrationtest/JBox2DSimulation.java
@@ -15,11 +15,10 @@
  */
 package de.mirkosertic.bytecoder.integrationtest;
 
-import de.mirkosertic.bytecoder.api.Export;
 import de.mirkosertic.bytecoder.api.Import;
 import de.mirkosertic.bytecoder.api.web.AnimationFrameCallback;
 import de.mirkosertic.bytecoder.api.web.CanvasRenderingContext2D;
-import de.mirkosertic.bytecoder.api.web.ClickEvent;
+import de.mirkosertic.bytecoder.api.web.MouseEvent;
 import de.mirkosertic.bytecoder.api.web.Document;
 import de.mirkosertic.bytecoder.api.web.EventListener;
 import de.mirkosertic.bytecoder.api.web.HTMLButton;
@@ -202,9 +201,9 @@ public class JBox2DSimulation {
         };
 
         final HTMLButton button = document.getElementById("button");
-        button.addEventListener("click", new EventListener<ClickEvent>() {
+        button.addEventListener("click", new EventListener<MouseEvent>() {
             @Override
-            public void run(final ClickEvent aValue) {
+            public void run(final MouseEvent aValue) {
                 button.disabled(true);
                 window.requestAnimationFrame(animationCallback);
             }

--- a/integrationtest/src/main/java/de/mirkosertic/bytecoder/integrationtest/VueDemo.java
+++ b/integrationtest/src/main/java/de/mirkosertic/bytecoder/integrationtest/VueDemo.java
@@ -20,7 +20,7 @@ import de.mirkosertic.bytecoder.api.vue.Vue;
 import de.mirkosertic.bytecoder.api.vue.VueBuilder;
 import de.mirkosertic.bytecoder.api.vue.VueEventListener;
 import de.mirkosertic.bytecoder.api.vue.VueInstance;
-import de.mirkosertic.bytecoder.api.web.ClickEvent;
+import de.mirkosertic.bytecoder.api.web.MouseEvent;
 
 public class VueDemo {
 
@@ -35,9 +35,9 @@ public class VueDemo {
         final VueBuilder<MyVueInstance> theBuilder = Vue.builder();
         theBuilder.bindToTemplateSelector("#vuetemplate");
         theBuilder.data().setProperty("welcomemessage", "hello world!");
-        theBuilder.addEventListener("clicked", new VueEventListener<MyVueInstance, ClickEvent>() {
+        theBuilder.addEventListener("clicked", new VueEventListener<MyVueInstance, MouseEvent>() {
             @Override
-            public void handle(final MyVueInstance instance, final ClickEvent event) {
+            public void handle(final MyVueInstance instance, final MouseEvent event) {
                 instance.welcomemessage(String.format("hello world, you have clicked. Timestamp is %s", System.currentTimeMillis()));
             }
         });

--- a/integrationtest/src/main/kotlin/de/mirkosertic/bytecoder/integrationtest/JBox2DSimulationKotlin.kt
+++ b/integrationtest/src/main/kotlin/de/mirkosertic/bytecoder/integrationtest/JBox2DSimulationKotlin.kt
@@ -20,7 +20,7 @@ import de.mirkosertic.bytecoder.api.Import
 import de.mirkosertic.bytecoder.api.web.AnimationFrameCallback
 import de.mirkosertic.bytecoder.api.web.CanvasRenderingContext2D
 import de.mirkosertic.bytecoder.api.web.EventListener
-import de.mirkosertic.bytecoder.api.web.ClickEvent
+import de.mirkosertic.bytecoder.api.web.MouseEvent
 import de.mirkosertic.bytecoder.api.web.HTMLButton
 import de.mirkosertic.bytecoder.api.web.HTMLCanvasElement
 import de.mirkosertic.bytecoder.api.web.Window
@@ -189,7 +189,7 @@ object JBox2DSimulationKotlin {
         }
 
         val button = document.getElementById<HTMLButton>("button")
-        button.addEventListener("click", EventListener<ClickEvent> {
+        button.addEventListener("click", EventListener<MouseEvent> {
             button.disabled(true)
             window!!.requestAnimationFrame(animationCallback)
         })


### PR DESCRIPTION
Rename ClickEvent to MouseEvent, following this convention/specification: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent

Also, following the same specification, adds [type()](https://developer.mozilla.org/en-US/docs/Web/API/Event/type) to Event (it is not ideal but is useful to handle multiple events with a single EventListener).