### PR TITLE
Add HTMLAudioElement

### DIFF
--- a/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/HTMLAudioElement.java
+++ b/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/HTMLAudioElement.java
@@ -1,0 +1,42 @@
+package de.mirkosertic.bytecoder.api.web;
+
+import de.mirkosertic.bytecoder.api.OpaqueProperty;
+
+public interface HTMLAudioElement extends HTMLElement {
+
+    @OpaqueProperty("loop")
+    void setLoop(boolean loop);
+
+    @OpaqueProperty("loop")
+    boolean isLoop();
+
+    @OpaqueProperty("volume")
+    void setVolume(float volume);
+
+    @OpaqueProperty("volume")
+    float getVolume();
+
+    @OpaqueProperty("currentTime")
+    void setCurrentTime(int currentTime);
+
+    @OpaqueProperty("currentTime")
+    int getCurrentTime();
+
+    @OpaqueProperty("paused")
+    boolean isPaused();
+
+    @OpaqueProperty("ended")
+    boolean isEnded();
+
+    void play();
+
+    void pause();
+
+    void stop();
+
+    @OpaqueProperty("src")
+    void setSrc(String url);
+
+    @OpaqueProperty("crossOrigin")
+    void setCrossOrigin(String crossOrigin);
+}


### PR DESCRIPTION
Add HTMLAudioElement, kindly borrowed from https://github.com/squins/gdx-backend-bytecoder

The attributes/methods follow the MDN Specification but for the sake of simplicity, it is not a subclass of HTMLMediaElement.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement
https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement