### PR TITLE
Make HTMLImageElement extends HTMLElement

### DIFF
--- a/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/HTMLImageElement.java
+++ b/classlib/bytecoder.web/src/main/java/de/mirkosertic/bytecoder/api/web/HTMLImageElement.java
@@ -19,7 +19,7 @@ package de.mirkosertic.bytecoder.api.web;
 import de.mirkosertic.bytecoder.api.OpaqueProperty;
 import de.mirkosertic.bytecoder.api.OpaqueReferenceType;
 
-public interface HTMLImageElement extends CanvasImageSource, OpaqueReferenceType {
+public interface HTMLImageElement extends CanvasImageSource, HTMLElement {
     @OpaqueProperty("alt")
     String getAlt();
 


### PR DESCRIPTION
I forgot to add this in the previous commit.

This is one of the last pieces to have [gdx-backend-bytecoder](https://github.com/squins/gdx-backend-bytecoder) fully supported by Bytecoder.