### PR TITLE
#525 SourceMap Error. How do I specify the SourceMap location?

### DIFF
--- a/core/src/main/java/de/mirkosertic/bytecoder/core/backend/wasm/ast/Module.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/core/backend/wasm/ast/Module.java
@@ -147,7 +147,9 @@ public class Module {
         if (enableDebug) {
             names.writeCodeTo(writer);
         }
-        sourceMapSection.writeTo(writer);
+
+        // Disabled, as source maps are currently not generated for Wasm
+        //sourceMapSection.writeTo(writer);
     }
 
     public String getLabel() {


### PR DESCRIPTION
- Disable source map section generation for Wasm as sourcemaps are currently not generated and supported.