### PR TITLE
Remove German "Die" and replace with english "the"

### DIFF
--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileJSCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileJSCommand.java
@@ -44,7 +44,7 @@ public class CompileJSCommand implements Callable<Integer> {
     @ParentCommand
     CompileCommand parent;
 
-    @Option(names = "-classpath", required = true, description = "Die Directory containing the JVM class files to be compiled.")
+    @Option(names = "-classpath", required = true, description = "The directory containing the JVM class files to be compiled.")
     protected String classpath;
 
     @Option(names = "-mainclass", required = true, description = "Name of the class that contains the main() method")

--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileWasmCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileWasmCommand.java
@@ -44,7 +44,7 @@ public class CompileWasmCommand implements Callable<Integer> {
     @ParentCommand
     CompileCommand parent;
 
-    @Option(names = "-classpath", required = true, description = "Die Directory containing the JVM class files to be compiled.")
+    @Option(names = "-classpath", required = true, description = "The directory containing the JVM class files to be compiled.")
     protected String classpath;
 
     @Option(names = "-mainclass", required = true, description = "Name of the class that contains the main() method")


### PR DESCRIPTION
While evaluating bytecoder i noticed the following simple typos.

Sidenotes:

1. Any particular reason for JPMS not being supported? I get that the current approach of loading files into the current classpath does not work particular well with this approach, but the maven jars cannot be depended on (e.g to call them in Java without ProcessBuilder). Might be related to 4 as well, given there are a lot of unnecessary dependencies (e.g. Testcontainers or selenium) bundled in the executable and their corresponding Maven artefacts. I would be willing to contribute some changes here too, but we should define the Scope of such changes before any work would just be rejected :).
2. The documentation seems to be wrong. bytecoderclasses.js or bytecoderruntime.js will be generated. I can contribute fixes to that as well, but i might be wrong.
3. Is it feasible to implement loading multiple Programms? I mean i could compile them seperately, but downloading the runtime for each is very costly. 
4. Writing or modifying existing ClassLibs seems unsupported or undocumented right now. In particular i would like to be able to override and implement my own Standard Output/Input/Error (System.out/in/err) without the default implementation. I understand being able just use the default Implementations is great and all, but being able to choose, replace or overwrite existing ones would be neat. For example for most Applications there is no need to have 300 lines of code for the Demo Hello World Programm. 