### PR TITLE
feat(cli): ` -classpath`  supporting multiple files/folders

### DIFF
--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/BytecoderCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/BytecoderCommand.java
@@ -15,8 +15,23 @@
  */
 package de.mirkosertic.bytecoder.cli;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+
 import static picocli.CommandLine.*;
 
 @Command(name = "bytecoder", subcommands = {GraphCommand.class, CompileCommand.class}, mixinStandardHelpOptions = true)
 public class BytecoderCommand {
+    public static URL[] parseClasspath(String classpath) {
+        return Arrays.stream(classpath.split(",")).map(path -> {
+            try {
+                return new File(path).toURI().toURL();
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        }).toArray(URL[]::new);
+    }
 }

--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileJSCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileJSCommand.java
@@ -34,8 +34,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 
+import static de.mirkosertic.bytecoder.cli.BytecoderCommand.parseClasspath;
 import static picocli.CommandLine.*;
 
 @Command(name = "js")
@@ -44,7 +46,7 @@ public class CompileJSCommand implements Callable<Integer> {
     @ParentCommand
     CompileCommand parent;
 
-    @Option(names = "-classpath", required = true, description = "The directory containing the JVM class files to be compiled.")
+    @Option(names = "-classpath", required = true, description = "The classpath containing the JVM class files and JARs to be compiled. Format: /path/to/classes,/path/to/some.jar.")
     protected String classpath;
 
     @Option(names = "-mainclass", required = true, description = "Name of the class that contains the main() method")
@@ -70,7 +72,7 @@ public class CompileJSCommand implements Callable<Integer> {
 
         try {
             final ClassLoader rootClassLoader = BytecoderCLI.class.getClassLoader();
-            final URLClassLoader classLoader = new URLClassLoader(new URL[] {new File(classpath).toURI().toURL()}, rootClassLoader);
+            final URLClassLoader classLoader = new URLClassLoader(parseClasspath(classpath), rootClassLoader);
 
             final Loader loader = new BytecoderLoader(classLoader);
 

--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileWasmCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/CompileWasmCommand.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.Callable;
 
+import static de.mirkosertic.bytecoder.cli.BytecoderCommand.parseClasspath;
 import static picocli.CommandLine.*;
 
 @Command(name = "wasm")
@@ -44,7 +45,7 @@ public class CompileWasmCommand implements Callable<Integer> {
     @ParentCommand
     CompileCommand parent;
 
-    @Option(names = "-classpath", required = true, description = "The directory containing the JVM class files to be compiled.")
+    @Option(names = "-classpath", required = true, description = "The classpath containing the JVM class files and JARs to be compiled. Format: /path/to/classes,/path/to/some.jar.")
     protected String classpath;
 
     @Option(names = "-mainclass", required = true, description = "Name of the class that contains the main() method")
@@ -73,7 +74,7 @@ public class CompileWasmCommand implements Callable<Integer> {
 
         try {
             final ClassLoader rootClassLoader = BytecoderCLI.class.getClassLoader();
-            final URLClassLoader classLoader = new URLClassLoader(new URL[]{new File(classpath).toURI().toURL()}, rootClassLoader);
+            final URLClassLoader classLoader = new URLClassLoader(parseClasspath(classpath), rootClassLoader);
 
             final Loader loader = new BytecoderLoader(classLoader);
 

--- a/cli/src/main/java/de/mirkosertic/bytecoder/cli/GraphGenerateCommand.java
+++ b/cli/src/main/java/de/mirkosertic/bytecoder/cli/GraphGenerateCommand.java
@@ -32,6 +32,7 @@ import java.net.URLClassLoader;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
+import static de.mirkosertic.bytecoder.cli.BytecoderCommand.parseClasspath;
 import static picocli.CommandLine.*;
 
 @Command(name = "generate")
@@ -40,7 +41,7 @@ public class GraphGenerateCommand implements Callable<Integer> {
     @ParentCommand
     GraphCommand parent;
 
-    @Option(names = "-classpath", required = true, description = "Die Directory containing the JVM class files to be compiled.")
+    @Option(names = "-classpath", required = true, description = "The classpath containing the JVM class files and JARs to be compiled. Format: /path/to/classes,/path/to/some.jar.")
     protected String classpath;
 
     @Option(names = "-mainclass", required = true, description = "Name of the class that contains the main() method")
@@ -60,7 +61,7 @@ public class GraphGenerateCommand implements Callable<Integer> {
 
         try {
             final ClassLoader rootClassLoader = BytecoderCLI.class.getClassLoader();
-            final URLClassLoader classLoader = new URLClassLoader(new URL[] {new File(classpath).toURI().toURL()}, rootClassLoader);
+            final URLClassLoader classLoader = new URLClassLoader(parseClasspath(classpath), rootClassLoader);
 
             final Loader loader = new BytecoderLoader(classLoader);
 

--- a/cli/src/test/java/de/mirkosertic/bytecoder/cli/BytecoderCLITest.java
+++ b/cli/src/test/java/de/mirkosertic/bytecoder/cli/BytecoderCLITest.java
@@ -38,10 +38,19 @@ public class BytecoderCLITest {
     public void testCompileToJS() {
         Assert.assertEquals(new CommandLine(new BytecoderCommand()).execute("compile", "js", "-builddirectory=./target", "-classpath=.", "-mainclass=de.mirkosertic.bytecoder.cli.BytecoderCLITest$MainClass"), 0);
     }
+    @Test
+    public void testCompileToJSMultipleClasspath() {
+        Assert.assertEquals(new CommandLine(new BytecoderCommand()).execute("compile", "js", "-builddirectory=./target", "-classpath=./some/nonexisting/path,.", "-mainclass=de.mirkosertic.bytecoder.cli.BytecoderCLITest$MainClass"), 0);
+    }
 
     @Test
     public void testCompileToWasm() {
         Assert.assertEquals(new CommandLine(new BytecoderCommand()).execute("compile", "wasm", "-builddirectory=./target", "-classpath=.", "-mainclass=de.mirkosertic.bytecoder.cli.BytecoderCLITest$MainClass"), 0);
+    }
+
+    @Test
+    public void testCompileToWasmMultipleClasspath() {
+        Assert.assertEquals(new CommandLine(new BytecoderCommand()).execute("compile", "wasm", "-builddirectory=./target", "-classpath=.,./some/nonexisiting/path", "-mainclass=de.mirkosertic.bytecoder.cli.BytecoderCLITest$MainClass"), 0);
     }
 
     @Test

--- a/manual/content/chapter-1/page-1-a.md
+++ b/manual/content/chapter-1/page-1-a.md
@@ -50,6 +50,7 @@ wget https://repo.maven.apache.org/maven2/de/mirkosertic/bytecoder/bytecoder-cli
 ```
 java -jar bytecoder-cli-{{% siteparam "bytecoderversion" %}}-executable.jar compile js -classpath=. -mainclass=bytecodertest.HelloWorld -builddirectory=.
 ```
+> **Note**: Keep in mind that `classpath` is comma seperated `,` and not semicolon `;` or colon `:`  as in the native java tools 
 
 **Step 3: Create an embedding HTML document**:
 


### PR DESCRIPTION
Often when compiling java the classpath consits of more than one folder - for example when dependencies are involved. This pr enables the cli to use classpaths in the format of ``-classpath=/path/to/classes,/path/to/jars/lib.jar``