### PR TITLE
feat(core): improved `No such method` traces

### DIFF
--- a/core/src/main/java/de/mirkosertic/bytecoder/core/ir/ResolvedClass.java
+++ b/core/src/main/java/de/mirkosertic/bytecoder/core/ir/ResolvedClass.java
@@ -23,6 +23,7 @@ import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.FieldNode;
 import org.objectweb.asm.tree.MethodNode;
 
+import java.io.*;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,9 +110,19 @@ public class ResolvedClass {
     public ResolvedMethod resolveMethod(final String methodName, final Type methodType, final AnalysisStack analysisStack) {
         final ResolvedMethod m = resolveMethodInternal(methodName, methodType, analysisStack, false);
         if (m == null) {
-            throw new IllegalStateException("No such method : " + classNode.name + "." + methodName + methodType);
+            throw new AnalysisException(
+                    new IllegalStateException("No such method : " + classNode.name + "." + methodName + methodType),
+                    analysisStack
+            );
         }
         return m;
+    }
+
+    private String printStackTrace(AnalysisStack analysisStack) {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        PrintStream stringStream = new PrintStream(bos);
+        analysisStack.dumpAnalysisStack(stringStream);
+        return "\n" + bos;
     }
 
     private ResolvedMethod resolveMethodInternal(final String methodName, final Type methodType, final AnalysisStack analysisStack, final boolean onlyImplementations) {


### PR DESCRIPTION
ref: #924

The implementation is not as good as proposed, but it does like 98% of the work and is a lot less time invested

Example of a new Exception:
```
Caused by: java.lang.IllegalStateException: No such method : java/lang/String.replace(Ljava/lang/CharSequence;Ljava/lang/CharSequence;)Ljava/lang/String;
Current Analysis Stack is : 
Parsing method body of Lexample/MainClass;.main
 Parsing method body of Lcom/niton/jsx/JsxComponents;.App
  Parsing method body of Lcom/niton/jsx/JsxComponents;.JsxParserComponent
   Parsing method body of Lexample/JsxParserComponent;.initialize
    Parsing method body of Lexample/JsxParserComponent;.lambda$initialize$0
      Start of try catch block at org.objectweb.asm.tree.LabelNode@8e1a17df with handler L188279188 and type com/niton/parser/exceptions/ParsingException
      Check of stack size is ok
      Visiting #36 ASTORE Stack size is 1 Source line 35
```